### PR TITLE
fix: preserve newline in the generated file

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Run Tests
         run: yarn test
 
+      - name: Release Patch
+        if: endsWith(github.ref, '/main')
+        run: yarn publish --patch
+
       # Note: not 1.0.0 yet, semantic-release only supports versions >1.0.0
       # - name: Release
       #   if: endsWith(github.ref, '/main')

--- a/src/fns/esbuild/bundle.test.ts
+++ b/src/fns/esbuild/bundle.test.ts
@@ -31,3 +31,23 @@ tap.test('getBundleJs - bad syntax', async (t) => {
   })
   t.rejects(js)
 })
+
+tap.test('getBundleJs - newline template', async (t) => {
+  const js = await getBundledJs({
+    inputFile: './src/fns/esbuild/test-fixtures/newline-template.fixture.ts',
+    mode: 'start_proc',
+    outputFolder: 'plv8ify-dist',
+    scopePrefix: 'plv8ify',
+  })
+  t.matchSnapshot(js)
+})
+
+tap.test('getBundleJs - newline string', async (t) => {
+  const js = await getBundledJs({
+    inputFile: './src/fns/esbuild/test-fixtures/newline-string.fixture.ts',
+    mode: 'start_proc',
+    outputFolder: 'plv8ify-dist',
+    scopePrefix: 'plv8ify',
+  })
+  t.matchSnapshot(js)
+})

--- a/src/fns/esbuild/test-fixtures/newline-string.fixture.ts
+++ b/src/fns/esbuild/test-fixtures/newline-string.fixture.ts
@@ -1,0 +1,4 @@
+export function sayHello() {
+  const greetString = 'hello' + '\n' + 'world'
+  return greetString
+}

--- a/src/fns/esbuild/test-fixtures/newline-template.fixture.ts
+++ b/src/fns/esbuild/test-fixtures/newline-template.fixture.ts
@@ -1,0 +1,4 @@
+export function sayHello() {
+  const greetTemplate = `hello \n world`
+  return greetTemplate
+}

--- a/src/fns/ts-morph/toSQL.test.ts
+++ b/src/fns/ts-morph/toSQL.test.ts
@@ -5,6 +5,7 @@ import { getSQLFunction } from './toSQL'
 tap.test('getSQLFunction with parameters', async (t) => {
   const sql = getSQLFunction({
     scopedName: 'plv8ify_test',
+    fnName: 'test',
     pgFunctionDelimiter: '$plv8ify$',
     paramsBind: '',
     paramsCall: '',
@@ -18,6 +19,7 @@ tap.test('getSQLFunction with parameters', async (t) => {
 tap.test('getSQLFunction with delimiter', async (t) => {
   const sql = getSQLFunction({
     scopedName: 'plv8ify_test',
+    fnName: 'test',
     pgFunctionDelimiter: '$function$',
     paramsBind: '',
     paramsCall: '',

--- a/src/fns/ts-morph/toSQL.ts
+++ b/src/fns/ts-morph/toSQL.ts
@@ -56,17 +56,16 @@ export const getSQLFunction = ({
   mode,
   bundledJs,
 }: GetSQLFunctionArgs) => {
-  return dedent(`DROP FUNCTION IF EXISTS ${scopedName}(${paramsBind});
-    CREATE OR REPLACE FUNCTION ${scopedName}(${paramsBind}) RETURNS ${fallbackType} AS ${pgFunctionDelimiter}
-    ${
-      // In inline mode, write the bundle text directly to the function
-      match(mode)
-        .with('inline', () => dedent(`${bundledJs}`))
-        .otherwise(() => ``)
-    }
-    return plv8ify.${scopedName}(${paramsCall})
-    
-    ${pgFunctionDelimiter} LANGUAGE plv8 IMMUTABLE STRICT;`)
+  return [
+    `DROP FUNCTION IF EXISTS ${scopedName}(${paramsBind});`,
+    `CREATE OR REPLACE FUNCTION ${scopedName}(${paramsBind}) RETURNS ${fallbackType} AS ${pgFunctionDelimiter}`,
+    match(mode)
+      .with('inline', () => bundledJs)
+      .otherwise(() => ''),
+    `return plv8ify.${scopedName}(${paramsCall})`,
+    '',
+    `${pgFunctionDelimiter} LANGUAGE plv8 IMMUTABLE STRICT;`,
+  ].join('\n')
 }
 
 interface GetSQLFunctionFileNameArgs {

--- a/src/fns/ts-morph/toSQL.ts
+++ b/src/fns/ts-morph/toSQL.ts
@@ -39,6 +39,7 @@ export const getBindParams = ({
 
 interface GetSQLFunctionArgs {
   scopedName: string
+  fnName: string
   pgFunctionDelimiter: string
   paramsBind: string
   paramsCall: string
@@ -49,6 +50,7 @@ interface GetSQLFunctionArgs {
 
 export const getSQLFunction = ({
   scopedName,
+  fnName,
   pgFunctionDelimiter,
   paramsBind,
   paramsCall,
@@ -62,7 +64,7 @@ export const getSQLFunction = ({
     match(mode)
       .with('inline', () => bundledJs)
       .otherwise(() => ''),
-    `return plv8ify.${scopedName}(${paramsCall})`,
+    `return plv8ify.${fnName}(${paramsCall})`,
     '',
     `${pgFunctionDelimiter} LANGUAGE plv8 IMMUTABLE STRICT;`,
   ].join('\n')

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,8 @@ async function main() {
       return
     }
 
-    const scopedName = scopePrefix + '_' + fnAst.getName()
+    const fnName = fnAst.getName()
+    const scopedName = scopePrefix + '_' + fnName
     const params = fnAst.getParameters()
 
     // Js to SQL type mapping happens here
@@ -113,6 +114,7 @@ async function main() {
 
     const SQLFunction = getSQLFunction({
       scopedName,
+      fnName,
       pgFunctionDelimiter,
       paramsBind,
       paramsCall,

--- a/tap-snapshots/src/fns/esbuild/bundle.test.ts.test.cjs
+++ b/tap-snapshots/src/fns/esbuild/bundle.test.ts.test.cjs
@@ -82,3 +82,82 @@ plv8ify = (() => {
 })();
 
 `
+
+exports[`src/fns/esbuild/bundle.test.ts TAP getBundleJs - newline string > must match snapshot 1`] = `
+plv8ify = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __reExport = (target, module, copyDefault, desc) => {
+    if (module && typeof module === "object" || typeof module === "function") {
+      for (let key of __getOwnPropNames(module))
+        if (!__hasOwnProp.call(target, key) && (copyDefault || key !== "default"))
+          __defProp(target, key, { get: () => module[key], enumerable: !(desc = __getOwnPropDesc(module, key)) || desc.enumerable });
+    }
+    return target;
+  };
+  var __toCommonJS = /* @__PURE__ */ ((cache) => {
+    return (module, temp) => {
+      return cache && cache.get(module) || (temp = __reExport(__markAsModule({}), module, 1), cache && cache.set(module, temp), temp);
+    };
+  })(typeof WeakMap !== "undefined" ? /* @__PURE__ */ new WeakMap() : 0);
+
+  // src/fns/esbuild/test-fixtures/newline-string.fixture.ts
+  var newline_string_fixture_exports = {};
+  __export(newline_string_fixture_exports, {
+    sayHello: () => sayHello
+  });
+  function sayHello() {
+    const greetString = "hello\\nworld";
+    return greetString;
+  }
+  return __toCommonJS(newline_string_fixture_exports);
+})();
+
+`
+
+exports[`src/fns/esbuild/bundle.test.ts TAP getBundleJs - newline template > must match snapshot 1`] = `
+plv8ify = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __reExport = (target, module, copyDefault, desc) => {
+    if (module && typeof module === "object" || typeof module === "function") {
+      for (let key of __getOwnPropNames(module))
+        if (!__hasOwnProp.call(target, key) && (copyDefault || key !== "default"))
+          __defProp(target, key, { get: () => module[key], enumerable: !(desc = __getOwnPropDesc(module, key)) || desc.enumerable });
+    }
+    return target;
+  };
+  var __toCommonJS = /* @__PURE__ */ ((cache) => {
+    return (module, temp) => {
+      return cache && cache.get(module) || (temp = __reExport(__markAsModule({}), module, 1), cache && cache.set(module, temp), temp);
+    };
+  })(typeof WeakMap !== "undefined" ? /* @__PURE__ */ new WeakMap() : 0);
+
+  // src/fns/esbuild/test-fixtures/newline-template.fixture.ts
+  var newline_template_fixture_exports = {};
+  __export(newline_template_fixture_exports, {
+    sayHello: () => sayHello
+  });
+  function sayHello() {
+    const greetTemplate = \`hello 
+ world\`;
+    return greetTemplate;
+  }
+  return __toCommonJS(newline_template_fixture_exports);
+})();
+
+`

--- a/tap-snapshots/src/fns/ts-morph/toSQL.test.ts.test.cjs
+++ b/tap-snapshots/src/fns/ts-morph/toSQL.test.ts.test.cjs
@@ -9,7 +9,7 @@ exports[`src/fns/ts-morph/toSQL.test.ts TAP getSQLFunction with delimiter > must
 DROP FUNCTION IF EXISTS plv8ify_test();
 CREATE OR REPLACE FUNCTION plv8ify_test() RETURNS JSONB AS $function$
 console.log("hello")
-return plv8ify.plv8ify_test()
+return plv8ify.test()
 
 $function$ LANGUAGE plv8 IMMUTABLE STRICT;
 `
@@ -18,7 +18,7 @@ exports[`src/fns/ts-morph/toSQL.test.ts TAP getSQLFunction with parameters > mus
 DROP FUNCTION IF EXISTS plv8ify_test();
 CREATE OR REPLACE FUNCTION plv8ify_test() RETURNS JSONB AS $plv8ify$
 console.log("hello")
-return plv8ify.plv8ify_test()
+return plv8ify.test()
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
 `


### PR DESCRIPTION
Fix https://github.com/divyenduz/plv8ify/issues/1

- Added tests for demonstrating behaviour of newline in templates and strings. Realized that the snapshots looked fine.
- Changed the rendering of the function to not use tagged template literals and use array of lines joined with `\n`. This preserves the newlines. 
- Piggyback: fixed a bug re-function scoping in the generated function. 

<img width="504" alt="CleanShot 2022-03-12 at 13 33 34@2x" src="https://user-images.githubusercontent.com/746482/158018099-ad5662fe-f4e9-4307-a8d8-86d1383774d5.png">
