### PR TITLE
fix: scope-prefix options return statement crash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,18 @@ import { Project } from 'ts-morph'
 import { getBundledJs } from './fns/esbuild/bundle'
 import {
   getClientInitFileName,
-  getClientInitSQL,
+  getClientInitSQL
 } from './fns/plv8/startProc/client'
 import {
   getInitFunction,
   getInitFunctionFilename,
-  getInitFunctionName,
+  getInitFunctionName
 } from './fns/plv8/startProc/init'
 import { getParamsCall } from './fns/ts-morph/toJs'
 import {
   getBindParams,
   getSQLFunction,
-  getSQLFunctionFileName,
+  getSQLFunctionFileName
 } from './fns/ts-morph/toSQL'
 import { writeFile } from './utils'
 
@@ -64,7 +64,7 @@ async function main() {
     mode,
     inputFile,
     outputFolder,
-    scopePrefix,
+    scopePrefix: 'plv8ify',
   })
 
   // Optionally, write ESBuild output file


### PR DESCRIPTION
Current code generates the following output when used with '--scope-prefix js'

```
CREATE OR REPLACE FUNCTION js_object_hash(data JSONB) RETURNS JSONB AS $plv8ify$
"use strict";
var js = (() => {
// ...
})();

return plv8ify.object_hash(data)

$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
```

Implemented simplest fix is to not change the internal variable name an leave it as is

```
CREATE OR REPLACE FUNCTION js_object_hash(data JSONB) RETURNS JSONB AS $plv8ify$
"use strict";
var plv8ify = (() => {
// ...
})();

return plv8ify.object_hash(data)

$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
```