### PR TITLE
feat(volatility): add --volatile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ See all examples in the [examples folder](/examples). Use `yarn examples` to app
 
 ## CLI Arguments
 
-| Generate Command Flags  | Type                     | Description                                                                                               | Default        |
-| ----------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------- | -------------- |
-| --debug                 | Boolean                  | Print additional debug information                                                                        | `false`        |
-| --write-esbuild-output  | Boolean                  | Write the intermediate bundled Javascript output from ESBuild                                             | `false`        |
-| --input-file            | String                   | Specify an input file path (only Typescript supported at the moment)                                      | `input.ts`     |
-| --output-folder         | String                   | Specify an output folder                                                                                  | `plv8ify-dist` |
-| --scope-prefix          | String                   | Specify a scope prefix, by default `plv8ify`, adds `plv8ify_` as prefix for exported typescript functions | `plv8ify`      |
-| --pg-function-delimiter | String                   | Specify a delimiter for the generated Postgres function                                                   | `$plv8ify$`    |
-| --fallback-type         | String                   | Specify a fallback type when `plv8ify` fails to map a detected Typescript type to a Postges type          | `JSONB`        |
-| --mode                  | 'inline' or 'start_proc' | Bundle the library inline in each function or bundle the libary to be used with plv8.start_proc           | `inline`       |
+| Generate Command Flags  | Type                                  | Description                                                                                                                                                                                                              | Default        |
+| ----------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| --debug                 | Boolean                               | Print additional debug information                                                                                                                                                                                       | `false`        |
+| --write-esbuild-output  | Boolean                               | Write the intermediate bundled Javascript output from ESBuild                                                                                                                                                            | `false`        |
+| --input-file            | String                                | Specify an input file path (only Typescript supported at the moment)                                                                                                                                                     | `input.ts`     |
+| --output-folder         | String                                | Specify an output folder                                                                                                                                                                                                 | `plv8ify-dist` |
+| --scope-prefix          | String                                | Specify a scope prefix, by default `plv8ify`, adds `plv8ify_` as prefix for exported typescript functions                                                                                                                | `plv8ify`      |
+| --pg-function-delimiter | String                                | Specify a delimiter for the generated Postgres function                                                                                                                                                                  | `$plv8ify$`    |
+| --fallback-type         | String                                | Specify a fallback type when `plv8ify` fails to map a detected Typescript type to a Postges type                                                                                                                         | `JSONB`        |
+| --mode                  | 'inline' or 'start_proc'              | Bundle the library inline in each function or bundle the libary to be used with plv8.start_proc                                                                                                                          | `inline`       |
+| --volatility            | 'IMMUTABLE' or 'STABLE' or 'VOLATILE' | Change the volatility of all the generated functions. To change volatility of a specific function use the comment format `//@plv8ify-volatility-STABLE` in the input typescript file (see `examples/turf-js/input.ts`). Note that for now only single-line comment syntax is supported. | `IMMUTABLE`    |
 
 ## Caveats
 

--- a/examples/turf-js/input.ts
+++ b/examples/turf-js/input.ts
@@ -4,3 +4,9 @@ export function point(lat: number, long: number) {
   const pt = turfPoint([lat, long])
   return pt
 }
+
+//@plv8ify-volatility-STABLE
+export function stablePoint(lat: number, long: number) {
+  const pt = turfPoint([lat, long])
+  return pt
+}

--- a/examples/turf-js/plv8ify-dist/plv8ify_stablePoint.plv8.sql
+++ b/examples/turf-js/plv8ify-dist/plv8ify_stablePoint.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS plv8ify_point(lat float8,long float8);
-CREATE OR REPLACE FUNCTION plv8ify_point(lat float8,long float8) RETURNS JSONB AS $plv8ify$
+DROP FUNCTION IF EXISTS plv8ify_stablePoint(lat float8,long float8);
+CREATE OR REPLACE FUNCTION plv8ify_stablePoint(lat float8,long float8) RETURNS JSONB AS $plv8ify$
 var plv8ify = (() => {
   var __defProp = Object.defineProperty;
   var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -410,6 +410,6 @@ var plv8ify = (() => {
   return __toCommonJS(input_exports);
 })();
 
-return plv8ify.point(lat,long)
+return plv8ify.stablePoint(lat,long)
 
-$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
+$plv8ify$ LANGUAGE plv8 STABLE STRICT;

--- a/src/fns/plv8/startProc/init.test.ts
+++ b/src/fns/plv8/startProc/init.test.ts
@@ -14,8 +14,12 @@ tap.test('getInitFunctionName', async (t) => {
 tap.test('getInitFunction', async (t) => {
   const initFunctionName = getInitFunctionName('plv8ify')
   const initFunction = getInitFunction(
-    initFunctionName,
-    `plv8.elog(NOTICE, plv8.version);`
+    {
+      fnName: initFunctionName,
+      source: `plv8.elog(NOTICE, plv8.version);`,
+      volatility: 'IMMUTABLE'
+    }
+
   )
 
   t.matchSnapshot(initFunction)

--- a/src/fns/plv8/startProc/init.ts
+++ b/src/fns/plv8/startProc/init.ts
@@ -1,5 +1,5 @@
 import dedent = require('dedent')
-import { Volatility } from 'src'
+import { Volatility } from '../../../'
 
 export const getInitFunctionName = (scopePrefix) => scopePrefix + '_init'
 

--- a/src/fns/plv8/startProc/init.ts
+++ b/src/fns/plv8/startProc/init.ts
@@ -1,12 +1,23 @@
 import dedent = require('dedent')
+import { Volatility } from 'src'
 
 export const getInitFunctionName = (scopePrefix) => scopePrefix + '_init'
 
-export const getInitFunction = (fnName: string, source: string) =>
+interface Options {
+  fnName: string
+  source: string
+  volatility: Volatility
+}
+
+export const getInitFunction = ({
+  fnName, 
+  source,
+  volatility
+}: Options) =>
   dedent(`DROP FUNCTION IF EXISTS ${fnName}();
 CREATE OR REPLACE FUNCTION ${fnName}() RETURNS VOID AS $$
 ${source}
-$$ LANGUAGE plv8 IMMUTABLE STRICT;
+$$ LANGUAGE plv8 ${volatility} STRICT;
 `)
 
 export const getInitFunctionFilename = (outputFolder: string, fnName: string) =>

--- a/src/fns/ts-morph/toSQL.test.ts
+++ b/src/fns/ts-morph/toSQL.test.ts
@@ -12,6 +12,7 @@ tap.test('getSQLFunction with parameters', async (t) => {
     fallbackType: 'JSONB',
     mode: 'inline',
     bundledJs: 'console.log("hello")',
+    volatility: 'IMMUTABLE'
   })
   t.matchSnapshot(sql)
 })
@@ -26,6 +27,7 @@ tap.test('getSQLFunction with delimiter', async (t) => {
     fallbackType: 'JSONB',
     mode: 'inline',
     bundledJs: 'console.log("hello")',
+    volatility: 'IMMUTABLE'
   })
   t.matchSnapshot(sql)
 })

--- a/src/fns/ts-morph/toSQL.ts
+++ b/src/fns/ts-morph/toSQL.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent'
 import { ParameterDeclaration } from 'ts-morph'
 import { match } from 'ts-pattern'
 
-import { Mode, Volatility } from '../..'
+import { Mode, Volatility } from '../../'
 
 const typeMap = {
   number: 'float8',

--- a/src/fns/ts-morph/toSQL.ts
+++ b/src/fns/ts-morph/toSQL.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent'
 import { ParameterDeclaration } from 'ts-morph'
 import { match } from 'ts-pattern'
 
-import { Mode } from '../..'
+import { Mode, Volatility } from '../..'
 
 const typeMap = {
   number: 'float8',
@@ -46,6 +46,7 @@ interface GetSQLFunctionArgs {
   fallbackType: string
   mode: Mode
   bundledJs: string
+  volatility: Volatility
 }
 
 export const getSQLFunction = ({
@@ -57,6 +58,7 @@ export const getSQLFunction = ({
   fallbackType,
   mode,
   bundledJs,
+  volatility
 }: GetSQLFunctionArgs) => {
   return [
     `DROP FUNCTION IF EXISTS ${scopedName}(${paramsBind});`,
@@ -66,7 +68,7 @@ export const getSQLFunction = ({
       .otherwise(() => ''),
     `return plv8ify.${fnName}(${paramsCall})`,
     '',
-    `${pgFunctionDelimiter} LANGUAGE plv8 IMMUTABLE STRICT;`,
+    `${pgFunctionDelimiter} LANGUAGE plv8 ${volatility} STRICT;`,
   ].join('\n')
 }
 

--- a/src/fns/ts-morph/toSQL.ts
+++ b/src/fns/ts-morph/toSQL.ts
@@ -1,5 +1,4 @@
 // TS to SQL helpers
-import dedent from 'dedent'
 import { ParameterDeclaration } from 'ts-morph'
 import { match } from 'ts-pattern'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,18 @@ import { Project } from 'ts-morph'
 import { getBundledJs } from './fns/esbuild/bundle'
 import {
   getClientInitFileName,
-  getClientInitSQL
+  getClientInitSQL,
 } from './fns/plv8/startProc/client'
 import {
   getInitFunction,
   getInitFunctionFilename,
-  getInitFunctionName
+  getInitFunctionName,
 } from './fns/plv8/startProc/init'
 import { getParamsCall } from './fns/ts-morph/toJs'
 import {
   getBindParams,
   getSQLFunction,
-  getSQLFunctionFileName
+  getSQLFunctionFileName,
 } from './fns/ts-morph/toSQL'
 import { writeFile } from './utils'
 
@@ -107,6 +107,12 @@ async function main() {
     const scopedName = scopePrefix + '_' + fnName
     const params = fnAst.getParameters()
 
+    const comments = fnAst.getLeadingCommentRanges().map((cr) => cr.getText())
+    const localVolatility = (comments
+      .filter((comment) => comment.includes('//@plv8ify-volatility-'))
+      .map((comment) => comment.replace('//@plv8ify-volatility-', ''))[0] ||
+      volatility) as Volatility
+
     // Js to SQL type mapping happens here
     const paramsBind = getBindParams({
       params,
@@ -128,7 +134,7 @@ async function main() {
       fallbackType,
       mode,
       bundledJs,
-      volatility
+      volatility: localVolatility,
     })
 
     const filename = getSQLFunctionFileName({


### PR DESCRIPTION
Fix https://github.com/divyenduz/plv8ify/issues/8

Added a `--volatility` flag to control the [volatility](https://www.postgresql.org/docs/current/xfunc-volatility.html) of the generated Postgres function. Considering making `VOLATILE` the default instead of `IMMUTABLE` as it is more flexible. 

Since, `plv8ify` can generate exported multiple functions from the input file and each can have different volatility, I will probably experiment a typescript comment based API to control that. Checking how easy/hard that is and might piggyback it to this PR. 