### PR TITLE
fix: Detect plv8 functions response type from typescript

### DIFF
--- a/examples/turf-js/input.ts
+++ b/examples/turf-js/input.ts
@@ -10,3 +10,8 @@ export function stablePoint(lat: number, long: number) {
   const pt = turfPoint([lat, long])
   return pt
 }
+
+export function stablePointAsString(lat: number, long: number) {
+  const pt = JSON.stringify(turfPoint([lat, long]))
+  return pt
+}

--- a/examples/turf-js/plv8ify-dist/plv8ify_stablePoint.plv8.sql
+++ b/examples/turf-js/plv8ify-dist/plv8ify_stablePoint.plv8.sql
@@ -396,7 +396,8 @@ var plv8ify = (() => {
   var input_exports = {};
   __export(input_exports, {
     point: () => point,
-    stablePoint: () => stablePoint
+    stablePoint: () => stablePoint,
+    stablePointAsString: () => stablePointAsString
   });
   var { point: turfPoint } = require_js();
   function point(lat, long) {
@@ -405,6 +406,10 @@ var plv8ify = (() => {
   }
   function stablePoint(lat, long) {
     const pt = turfPoint([lat, long]);
+    return pt;
+  }
+  function stablePointAsString(lat, long) {
+    const pt = JSON.stringify(turfPoint([lat, long]));
     return pt;
   }
   return __toCommonJS(input_exports);

--- a/examples/turf-js/plv8ify-dist/plv8ify_stablePointAsString.plv8.sql
+++ b/examples/turf-js/plv8ify-dist/plv8ify_stablePointAsString.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS plv8ify_point(lat float8,long float8);
-CREATE OR REPLACE FUNCTION plv8ify_point(lat float8,long float8) RETURNS JSONB AS $plv8ify$
+DROP FUNCTION IF EXISTS plv8ify_stablePointAsString(lat float8,long float8);
+CREATE OR REPLACE FUNCTION plv8ify_stablePointAsString(lat float8,long float8) RETURNS text AS $plv8ify$
 var plv8ify = (() => {
   var __defProp = Object.defineProperty;
   var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -415,6 +415,6 @@ var plv8ify = (() => {
   return __toCommonJS(input_exports);
 })();
 
-return plv8ify.point(lat,long)
+return plv8ify.stablePointAsString(lat,long)
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/src/fns/ts-morph/toSQL.test.ts
+++ b/src/fns/ts-morph/toSQL.test.ts
@@ -9,7 +9,7 @@ tap.test('getSQLFunction with parameters', async (t) => {
     pgFunctionDelimiter: '$plv8ify$',
     paramsBind: '',
     paramsCall: '',
-    fallbackType: 'JSONB',
+    returnType: 'JSONB',
     mode: 'inline',
     bundledJs: 'console.log("hello")',
     volatility: 'IMMUTABLE'
@@ -24,7 +24,7 @@ tap.test('getSQLFunction with delimiter', async (t) => {
     pgFunctionDelimiter: '$function$',
     paramsBind: '',
     paramsCall: '',
-    fallbackType: 'JSONB',
+    returnType: 'JSONB',
     mode: 'inline',
     bundledJs: 'console.log("hello")',
     volatility: 'IMMUTABLE'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,19 @@ import { Project } from 'ts-morph'
 import { getBundledJs } from './fns/esbuild/bundle'
 import {
   getClientInitFileName,
-  getClientInitSQL,
+  getClientInitSQL
 } from './fns/plv8/startProc/client'
 import {
   getInitFunction,
   getInitFunctionFilename,
-  getInitFunctionName,
+  getInitFunctionName
 } from './fns/plv8/startProc/init'
 import { getParamsCall } from './fns/ts-morph/toJs'
 import {
   getBindParams,
+  getReturnType,
   getSQLFunction,
-  getSQLFunctionFileName,
+  getSQLFunctionFileName
 } from './fns/ts-morph/toSQL'
 import { writeFile } from './utils'
 
@@ -125,13 +126,18 @@ async function main() {
       params,
     })
 
+    const returnType = getReturnType({
+      type: fnAst,
+      fallbackType,
+    })
+
     const SQLFunction = getSQLFunction({
       scopedName,
       fnName,
       pgFunctionDelimiter,
       paramsBind,
       paramsCall,
-      fallbackType,
+      returnType,
       mode,
       bundledJs,
       volatility: localVolatility,


### PR DESCRIPTION
Not sure how much the fallbackType option is used as it will be in almost all cases `any`/`jsonb` but i kept it as is and reused it for the return type also.