### PR TITLE
fix(build): fix prod build

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -43,16 +43,16 @@ jobs:
       - name: Run Tests
         run: bun test
 
-      # - name: Release Patch
-      #   if: endsWith(github.ref, '/main')
-      #   run: |
-      #     git config --global user.email "mail@divyendusingh.com"
-      #     git config --global user.name "Divyendu Singh"
-      #     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-      #     bun run build
-      #     npm version patch
-      #     npm publish
-      #     git push origin main
+      - name: Release Patch
+        if: endsWith(github.ref, '/main')
+        run: |
+          git config --global user.email "mail@divyendusingh.com"
+          git config --global user.name "Divyendu Singh"
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          bun run build
+          npm version patch
+          npm publish
+          git push origin main
 
       # Note: not 1.0.0 yet, semantic-release only supports versions >1.0.0
       # - name: Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "plv8ify",
   "version": "0.0.45",
+  "type": "module",
   "main": "dist/index.js",
   "license": "MIT",
   "bin": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,8 +3,8 @@ import fs from 'fs'
 import path from 'path'
 import task from 'tasuku'
 
-import { Database } from '../helpers/Database'
-import { ParseCLI } from '../helpers/ParseCLI'
+import { Database } from '../helpers/Database.js'
+import { ParseCLI } from '../helpers/ParseCLI.js'
 
 dotenv.config()
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
-import { ParseCLI } from '../helpers/ParseCLI'
-import { PLV8ifyCLI } from 'src/impl/PLV8ifyCLI'
+import { ParseCLI } from '../helpers/ParseCLI.js'
+import { PLV8ifyCLI } from '../impl/PLV8ifyCLI.js'
 
 export async function generateCommand(
   CLI: ReturnType<typeof ParseCLI.getCommand>

--- a/src/helpers/ParseCLI.ts
+++ b/src/helpers/ParseCLI.ts
@@ -1,5 +1,5 @@
 import arg from 'arg'
-import { Mode, Volatility } from 'src/interfaces/PLV8ify'
+import { Mode, Volatility } from 'src/interfaces/PLV8ify.js'
 
 type Command = 'version' | 'generate' | 'deploy'
 export type BundlerType = 'esbuild' | 'bun'

--- a/src/impl/BunBuild.ts
+++ b/src/impl/BunBuild.ts
@@ -1,4 +1,4 @@
-import { BundleArgs, Bundler } from 'src/interfaces/Bundler'
+import { BundleArgs, Bundler } from 'src/interfaces/Bundler.js'
 import nodeExternals from 'webpack-node-externals'
 
 class BundlerError extends Error {}

--- a/src/impl/EsBuild.ts
+++ b/src/impl/EsBuild.ts
@@ -1,5 +1,5 @@
 import { build } from 'esbuild'
-import { BundleArgs, Bundler } from 'src/interfaces/Bundler'
+import { BundleArgs, Bundler } from 'src/interfaces/Bundler.js'
 import nodeExternals from 'webpack-node-externals'
 
 class BundlerError extends Error {}

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -1,22 +1,22 @@
 import fs, { Mode } from 'fs'
-import { BundlerType } from 'src/helpers/ParseCLI'
-import { Bundler } from 'src/interfaces/Bundler'
+import { BundlerType } from 'src/helpers/ParseCLI.js'
+import { Bundler } from 'src/interfaces/Bundler.js'
 import {
   BuildArgs,
   GetPLV8SQLFunctionsArgs,
   PLV8ify,
   Volatility,
-} from 'src/interfaces/PLV8ify'
+} from 'src/interfaces/PLV8ify.js'
 import {
   TSCompiler,
   TSFunction,
   TSFunctionParameter,
-} from 'src/interfaces/TSCompiler'
+} from 'src/interfaces/TSCompiler.js'
 import { match } from 'ts-pattern'
 
-import { BunBuild } from './BunBuild'
-import { EsBuild } from './EsBuild'
-import { TsMorph } from './TsMorph'
+import { BunBuild } from './BunBuild.js'
+import { EsBuild } from './EsBuild.js'
+import { TsMorph } from './TsMorph.js'
 
 interface GetPLV8SQLFunctionArgs {
   fn: TSFunction

--- a/src/impl/TsMorph.ts
+++ b/src/impl/TsMorph.ts
@@ -1,4 +1,4 @@
-import { TSCompiler } from 'src/interfaces/TSCompiler'
+import { TSCompiler } from 'src/interfaces/TSCompiler.js'
 import { FunctionDeclaration, Project, SourceFile } from 'ts-morph'
 
 export class TsMorph implements TSCompiler {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { match } from 'ts-pattern'
 
-import { deployCommand } from './commands/deploy'
-import { generateCommand } from './commands/generate'
-import { versionCommand } from './commands/version'
-import { ParseCLI } from './helpers/ParseCLI'
+import { deployCommand } from './commands/deploy.js'
+import { generateCommand } from './commands/generate.js'
+import { versionCommand } from './commands/version.js'
+import { ParseCLI } from './helpers/ParseCLI.js'
 
 type Runtime = 'node' | 'bun'
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": false,
+
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
   },
   "exclude": [
     "**/*.test.ts",


### PR DESCRIPTION
Moved development setup to bun via
- https://github.com/divyenduz/plv8ify/pull/34
- https://github.com/divyenduz/plv8ify/pull/33

That broke the production build, reason, switched to using "esm", and added type "module" to `package.json` i.e. imports need extension. 

Also, #33 introduced bun bundler that can only be used in a bun runtime. How the CLI will use bun at runtime is interesting! But for now, this PR concludes moving development environment to bun and production via node CLI.