### PR TITLE
Feature: Implement overriding postgres types using a custom type map

### DIFF
--- a/examples/hello-custom-type/input.ts
+++ b/examples/hello-custom-type/input.ts
@@ -1,4 +1,4 @@
-interface test_type {
+export interface test_type {
   name: string
   age: number
 }

--- a/examples/hello-custom-type/input.ts
+++ b/examples/hello-custom-type/input.ts
@@ -1,0 +1,11 @@
+interface test_type {
+  name: string
+  age: number
+}
+
+export function hello(test: test_type[]): test_type {
+  return {
+    name: `Hello ${test[0].name}`,
+    age: test[0].age,
+  }
+}

--- a/examples/hello-custom-type/plv8ify-dist/plv8ify_hello.plv8.sql
+++ b/examples/hello-custom-type/plv8ify-dist/plv8ify_hello.plv8.sql
@@ -1,0 +1,14 @@
+DROP FUNCTION IF EXISTS plv8ify_hello(test test_type[]);
+CREATE OR REPLACE FUNCTION plv8ify_hello(test test_type[]) RETURNS test_type AS $plv8ify$
+// input.ts
+function hello(test) {
+  return {
+    name: `Hello ${test[0].name}`,
+    age: test[0].age
+  };
+}
+
+
+return hello(test)
+
+$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/hello-custom-type/types.js
+++ b/examples/hello-custom-type/types.js
@@ -1,0 +1,8 @@
+typeMap = {
+  number: 'float8',
+  string: 'text',
+  boolean: 'boolean',
+  Uint8: 'bytea',
+  test_type: 'test_type',
+  'test_type[]': 'test_type[]',
+}

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -16,12 +16,13 @@ export async function generateCommand(
     fallbackReturnType,
     mode,
     defaultVolatility,
+    typesFilePath,
   } = CLI.config
 
   fs.mkdirSync(outputFolderPath, { recursive: true })
 
   const plv8ify = new PLV8ifyCLI(bundler)
-  plv8ify.init(inputFilePath)
+  plv8ify.init(inputFilePath, typesFilePath)
 
   const bundledJs = await plv8ify.build({
     mode,

--- a/src/helpers/ParseCLI.ts
+++ b/src/helpers/ParseCLI.ts
@@ -11,6 +11,7 @@ export class ParseCLI {
     const args = arg({
       '--input-file': String,
       '--output-folder': String,
+      '--types-config-file': String,
       '--bundler': String, // 'esbuild' or 'bun'
       '--write-bundler-output': Boolean,
       '--scope-prefix': String,
@@ -40,6 +41,7 @@ Please specify a command. Available commands: generate, version, deploy
     const mode = (args['--mode'] || 'inline') as Mode
     const defaultVolatility = (args['--volatility'] ||
       'IMMUTABLE') as Volatility
+    const typesFilePath = args['--types-config-file'] || 'types.ts'
 
     return {
       command: args._[0] as Command,
@@ -54,6 +56,7 @@ Please specify a command. Available commands: generate, version, deploy
         fallbackReturnType,
         mode,
         defaultVolatility,
+        typesFilePath,
       },
     }
   }

--- a/src/impl/PLV8ifyCLI.test.ts
+++ b/src/impl/PLV8ifyCLI.test.ts
@@ -94,4 +94,31 @@ function test() {
     })
     expect(sql).toMatchSnapshot()
   })
+
+  it('getSQLFunction with custom type', async () => {
+    const plv8ify = new PLV8ifyCLI()
+    plv8ify.init('', './src/test-fixtures/types-custom.fixture.js')
+
+    const sql = plv8ify.getPLV8SQLFunction({
+      fn: {
+        name: 'test',
+        parameters: [{ name: 'test', type: 'test_type[]' }],
+        comments: [],
+      } as TSFunction,
+      scopePrefix: 'plv8ify',
+      mode: 'inline',
+      defaultVolatility: 'IMMUTABLE',
+      bundledJs: `
+      export function hello(test: test_type[]) {
+        return {
+          name: "Hello" + test[0].name,
+          age: test[0].age,
+        }
+      }      
+      `,
+      pgFunctionDelimiter: '$plv8ify$',
+      fallbackReturnType: 'JSONB',
+    })
+    expect(sql).toMatchSnapshot()
+  })
 })

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -55,8 +55,14 @@ export class PLV8ifyCLI implements PLV8ify {
     this._tsCompiler = new TsMorph()
   }
 
-  init(inputFilePath: string) {
-    this._tsCompiler.createSourceFile(inputFilePath)
+  init(inputFilePath: string, typesFilePath?: string) {
+    if (fs.existsSync(inputFilePath)) {
+      this._tsCompiler.createSourceFile(inputFilePath)
+    }
+    this._typeMap = {
+      ...this._typeMap,
+      ...this.getCustomTypeMap(typesFilePath),
+    }
   }
 
   private removeExportBlock(bundledJs: string) {
@@ -91,6 +97,17 @@ export class PLV8ifyCLI implements PLV8ify {
 
   write(path: string, string: string) {
     this.writeFile(path, string)
+  }
+
+  private getCustomTypeMap(typesFilePath: string) {
+    let customTypeMap = null
+    let typeMap = {}
+    if (fs.existsSync(typesFilePath)) {
+      customTypeMap = fs.readFileSync(typesFilePath, 'utf8')
+      eval(customTypeMap)
+      return typeMap
+    }
+    return {}
   }
 
   private getScopedName(fn: TSFunction, scopePrefix: string) {

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -106,6 +106,8 @@ export class PLV8ifyCLI implements PLV8ify {
       customTypeMap = fs.readFileSync(typesFilePath, 'utf8')
       eval(customTypeMap)
       return typeMap
+    } else {
+      console.log(`Not found types file: ${typesFilePath}`)
     }
     return {}
   }
@@ -123,6 +125,11 @@ export class PLV8ifyCLI implements PLV8ify {
     const scopedName = this.getScopedName(fn, scopePrefix)
     return `${outputFolder}/${scopedName}.plv8.sql`
   }
+  private getTypeFromMap(type: string) {
+    const typeLocal = type.split('.').pop()
+    //console.log(`Original type: ${type}, Converted type: ${typeLocal} `)
+    return this._typeMap[typeLocal ?? type]
+  }
 
   private getFunctions() {
     return this._tsCompiler.getFunctions().map((fn) => {
@@ -131,7 +138,7 @@ export class PLV8ifyCLI implements PLV8ify {
       }
       return {
         ...fn,
-        returnType: this._typeMap[fn.returnType],
+        returnType: this.getTypeFromMap(fn.returnType),
       }
     })
   }
@@ -178,7 +185,7 @@ export class PLV8ifyCLI implements PLV8ify {
     return parameters
       .map((p) => {
         const { name, type } = p
-        const mappedType = this._typeMap[type] || fallbackReturnType
+        const mappedType = this.getTypeFromMap(type) || fallbackReturnType
         return `${name} ${mappedType}`
       })
       .join(',')

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -127,7 +127,6 @@ export class PLV8ifyCLI implements PLV8ify {
   }
   private getTypeFromMap(type: string) {
     const typeLocal = type.split('.').pop()
-    //console.log(`Original type: ${type}, Converted type: ${typeLocal} `)
     return this._typeMap[typeLocal ?? type]
   }
 

--- a/src/impl/__snapshots__/PLV8ifyCLI.test.ts.snap
+++ b/src/impl/__snapshots__/PLV8ifyCLI.test.ts.snap
@@ -51,3 +51,19 @@ return test()
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;"
 `;
+
+exports[`PLV8ifyCLI tests getSQLFunction with custom type 1`] = `
+"DROP FUNCTION IF EXISTS plv8ify_test(test test_type[]);
+CREATE OR REPLACE FUNCTION plv8ify_test(test test_type[]) RETURNS JSONB AS $plv8ify$
+
+      export function hello(test: test_type[]) {
+        return {
+          name: "Hello" + test[0].name,
+          age: test[0].age,
+        }
+      }      
+      
+return test(test)
+
+$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;"
+`;

--- a/src/test-fixtures/types-custom.fixture.js
+++ b/src/test-fixtures/types-custom.fixture.js
@@ -1,0 +1,4 @@
+typeMap = {
+  test_type: 'test_type',
+  'test_type[]': 'test_type[]',
+}


### PR DESCRIPTION
Refs https://github.com/divyenduz/plv8ify/issues/27
Implements custom type mapping by
- introducing a new flag (--types-config-file )
- supporting type overrides/additions by including a config file (default, types.ts in the running dir)
- allowing types/interfaces to be imported from other files and still match them against the custom map