### PR TITLE
JSDoc support, Bundle mode fix, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ return hello(test)
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
 ```
 
+Additionally, you can decorate your functions with the `//@plv8ify-return <SQL TYPE>`, which allows setting the return type per function, and overrides the configuration in `typeMap`
+
 ## CLI Usage
 
 ### Version

--- a/README.md
+++ b/README.md
@@ -163,7 +163,49 @@ return hello(test)
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
 ```
 
-Additionally, you can decorate your functions with the `//@plv8ify-return <SQL TYPE>`, which allows setting the return type per function, and overrides the configuration in `typeMap`
+Additionally, you can decorate your functions with the `//@plv8ify-return <SQL TYPE>` comment, which allows setting the return type per function, and overrides the configuration in `typeMap`
+
+Similarly, parameter types can be set per function and per parameter with the `//@plv8ify-param <PARAM NAME> <SQL TYPE>` comment
+
+Example:
+input.ts
+
+```ts
+//@plv8ify-param first_name varchar(255)
+//@plv8ify-param last_name text
+//@plv8ify-return char(255)
+export function howdy(first_name: string, last_name: string): string {
+  return `Howdy ${first_name} ${last_name}`
+}
+```
+
+cli command line:
+
+```
+plv8ify generate input.ts
+```
+
+will generate this function:
+
+```sql
+DROP FUNCTION IF EXISTS howdy(first_name varchar(255),last_name text);
+CREATE OR REPLACE FUNCTION howdy(first_name varchar(255),last_name text) RETURNS char(255) AS $plv8ify$
+// examples/hello-custom-type/input.ts
+function hello(test) {
+  return {
+    name: `Hello ${test[0].name}`,
+    age: test[0].age
+  };
+}
+function howdy(first_name, last_name) {
+  return `Howdy ${first_name} ${last_name}`;
+}
+
+
+return howdy(first_name,last_name)
+
+$plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
+```
 
 ## CLI Usage
 

--- a/examples/common-types/plv8ify-dist/hello.plv8.sql
+++ b/examples/common-types/plv8ify-dist/hello.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS hello(test JSONB);
-CREATE OR REPLACE FUNCTION hello(test JSONB) RETURNS JSONB AS $plv8ify$
+DROP FUNCTION IF EXISTS hello(test test_type[]);
+CREATE OR REPLACE FUNCTION hello(test test_type[]) RETURNS test_type AS $plv8ify$
 // examples/common-types/input.ts
 function hello(test) {
   return {

--- a/examples/common-types/types.ts
+++ b/examples/common-types/types.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 typeMap = {
   number: 'float8',
   string: 'text',

--- a/examples/hello-bundle/plv8ify-dist/myScope_init.plv8.sql
+++ b/examples/hello-bundle/plv8ify-dist/myScope_init.plv8.sql
@@ -1,5 +1,5 @@
 DROP FUNCTION IF EXISTS myScope_init();
-CREATE OR REPLACE FUNCTION myScope_init() RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION myScope_init() RETURNS void AS $$
 // examples/hello-bundle/input.ts
 function hello() {
   return "world";
@@ -7,6 +7,8 @@ function hello() {
 function world() {
   return "hello";
 }
+
+
 
 
 $$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/hello-bundle/plv8ify-dist/myScope_init.plv8.sql
+++ b/examples/hello-bundle/plv8ify-dist/myScope_init.plv8.sql
@@ -8,6 +8,9 @@ function world() {
   return "hello";
 }
 
+globalThis.hello = hello;
+globalThis.world = world;
+globalThis[Symbol.for('myScope_initialized')] = true;
 
 
 

--- a/examples/hello-bundle/plv8ify-dist/myScopehello.plv8.sql
+++ b/examples/hello-bundle/plv8ify-dist/myScopehello.plv8.sql
@@ -1,6 +1,6 @@
 DROP FUNCTION IF EXISTS myScopehello();
 CREATE OR REPLACE FUNCTION myScopehello() RETURNS text AS $plv8ify$
-if (globalThis.myScope === undefined) plv8.execute('SELECT myScope_init();');
+if (!globalThis[Symbol.for('myScope_initialized')]) plv8.execute('SELECT myScope_init();');
 return hello()
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/hello-bundle/plv8ify-dist/myScopeworld.plv8.sql
+++ b/examples/hello-bundle/plv8ify-dist/myScopeworld.plv8.sql
@@ -1,6 +1,6 @@
 DROP FUNCTION IF EXISTS myScopeworld();
 CREATE OR REPLACE FUNCTION myScopeworld() RETURNS text AS $plv8ify$
-if (globalThis.myScope === undefined) plv8.execute('SELECT myScope_init();');
+if (!globalThis[Symbol.for('myScope_initialized')]) plv8.execute('SELECT myScope_init();');
 return world()
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/hello-custom-type/input.ts
+++ b/examples/hello-custom-type/input.ts
@@ -10,9 +10,11 @@ export function hello(test: test_type[]): test_type {
   }
 }
 
-//@plv8ify-param first_name varchar(255)
-//@plv8ify-param last_name text
-//@plv8ify-return char(255)
+/**
+ * @plv8ify_param {varchar(255)} first_name
+ * @plv8ify_param {text} last_name
+ * @plv8ify_return {char(255)}
+ */
 export function howdy(first_name: string, last_name: string): string {
   return `Howdy ${first_name} ${last_name}`
 }

--- a/examples/hello-custom-type/input.ts
+++ b/examples/hello-custom-type/input.ts
@@ -9,3 +9,8 @@ export function hello(test: test_type[]): test_type {
     age: test[0].age,
   }
 }
+
+//@plv8ify-return char(255)
+export function howdy(first_name: string, last_name: string): string {
+  return `Howdy ${first_name} ${last_name}`
+}

--- a/examples/hello-custom-type/input.ts
+++ b/examples/hello-custom-type/input.ts
@@ -10,6 +10,8 @@ export function hello(test: test_type[]): test_type {
   }
 }
 
+//@plv8ify-param first_name varchar(255)
+//@plv8ify-param last_name text
 //@plv8ify-return char(255)
 export function howdy(first_name: string, last_name: string): string {
   return `Howdy ${first_name} ${last_name}`

--- a/examples/hello-custom-type/plv8ify-dist/hello.plv8.sql
+++ b/examples/hello-custom-type/plv8ify-dist/hello.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS hello(test JSONB);
-CREATE OR REPLACE FUNCTION hello(test JSONB) RETURNS JSONB AS $plv8ify$
+DROP FUNCTION IF EXISTS hello(test test_type[]);
+CREATE OR REPLACE FUNCTION hello(test test_type[]) RETURNS test_type AS $plv8ify$
 // examples/hello-custom-type/input.ts
 function hello(test) {
   return {

--- a/examples/hello-custom-type/plv8ify-dist/howdy.plv8.sql
+++ b/examples/hello-custom-type/plv8ify-dist/howdy.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS howdy(first_name text,last_name text);
-CREATE OR REPLACE FUNCTION howdy(first_name text,last_name text) RETURNS char(255) AS $plv8ify$
+DROP FUNCTION IF EXISTS howdy(first_name varchar(255),last_name text);
+CREATE OR REPLACE FUNCTION howdy(first_name varchar(255),last_name text) RETURNS char(255) AS $plv8ify$
 // examples/hello-custom-type/input.ts
 function hello(test) {
   return {

--- a/examples/hello-custom-type/plv8ify-dist/howdy.plv8.sql
+++ b/examples/hello-custom-type/plv8ify-dist/howdy.plv8.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS hello(test test_type[]);
-CREATE OR REPLACE FUNCTION hello(test test_type[]) RETURNS test_type AS $plv8ify$
+DROP FUNCTION IF EXISTS howdy(first_name text,last_name text);
+CREATE OR REPLACE FUNCTION howdy(first_name text,last_name text) RETURNS char(255) AS $plv8ify$
 // examples/hello-custom-type/input.ts
 function hello(test) {
   return {
@@ -12,6 +12,6 @@ function howdy(first_name, last_name) {
 }
 
 
-return hello(test)
+return howdy(first_name,last_name)
 
 $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/hello-custom-type/types.ts
+++ b/examples/hello-custom-type/types.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 typeMap = {
   number: 'float8',
   string: 'text',

--- a/examples/hello-start_proc/plv8ify-dist/_init.plv8.sql
+++ b/examples/hello-start_proc/plv8ify-dist/_init.plv8.sql
@@ -1,5 +1,5 @@
 DROP FUNCTION IF EXISTS _init();
-CREATE OR REPLACE FUNCTION _init() RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION _init() RETURNS void AS $$
 // examples/hello-start_proc/input.ts
 function hello() {
   return "world";
@@ -7,6 +7,8 @@ function hello() {
 function world() {
   return "hello";
 }
+
+
 
 
 $$ LANGUAGE plv8 IMMUTABLE STRICT;

--- a/examples/trigger/input.ts
+++ b/examples/trigger/input.ts
@@ -5,7 +5,7 @@ type Row = {
   event_date_time: Date
 }
 
-//@plv8ify-trigger
+/** @plv8ify_trigger */
 export function test(NEW: Row, OLD: Row): Row {
   plv8.elog(NOTICE, 'NEW = ', JSON.stringify(NEW))
   plv8.elog(NOTICE, 'OLD = ', JSON.stringify(OLD))

--- a/examples/turf-js/input.ts
+++ b/examples/turf-js/input.ts
@@ -5,7 +5,7 @@ export function point(lat: number, long: number) {
   return pt
 }
 
-//@plv8ify-volatility-STABLE
+/** @plv8ify_volatility STABLE */
 export function stablePoint(lat: number, long: number) {
   const pt = turfPoint([lat, long])
   return pt

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "example:react-js": "bun run --bun src/index.ts generate --input-file examples/react-js/input.tsx --output-folder examples/react-js/plv8ify-dist",
     "example:trackfootball": "bun run --bun src/index.ts generate --input-file examples/trackfootball/input.tsx --output-folder examples/trackfootball/plv8ify-dist",
     "example:object-hash": "bun run --bun src/index.ts generate --input-file examples/object-hash/input.ts --output-folder examples/object-hash/plv8ify-dist",
-    "example:common-types": "bun run --bun src/index.ts generate --input-file examples/common-types/input.ts --output-folder examples/common-types/plv8ify-dist",
-    "example:hello-custom-type": "bun run --bun src/index.ts generate --input-file examples/hello-custom-type/input.ts --output-folder examples/hello-custom-type/plv8ify-dist",
+    "example:common-types": "bun run --bun src/index.ts generate --input-file examples/common-types/input.ts --types-config-file examples/common-types/types.ts --output-folder examples/common-types/plv8ify-dist",
+    "example:hello-custom-type": "bun run --bun src/index.ts generate --input-file examples/hello-custom-type/input.ts --types-config-file examples/hello-custom-type/types.ts --output-folder examples/hello-custom-type/plv8ify-dist",
     "example:trigger": "bun run --bun src/index.ts generate --input-file examples/trigger/input.ts --output-folder examples/trigger/plv8ify-dist",
     "examples": "bun example:hello; bun example:hello-start_proc; bun example:hello-bundle; bun example:turf-js; bun example:turf-js-distance; bun example:mathjs; bun example:react-js; bun example:object-hash; bun example:turf-js-distance; bun example:common-types; bun example:hello-custom-type; bun example:trigger"
   }

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -174,14 +174,25 @@ export class PLV8ifyCLI implements PLV8ify {
   ) {
     // special case: trigger
     if (PLV8ifyCLI.isTrigger(fn)) {
-      return '';
+      return ''; // trigger fns don't have parameters
     }
 
     return fn.parameters
       .map((p) => {
         const { name, type } = p
-        const mappedType = this.getTypeFromMap(type) || fallbackReturnType
-        return `${name} ${mappedType}`
+
+        // set by comment?
+        for (const comment of fn.comments) {
+          const paramMatch = comment.match(
+            new RegExp(`^//@plv8ify-param\\s${name}\\s(.*)`)
+          )
+          if (paramMatch) {
+            return `${name} ${paramMatch[1]}`
+          }
+        }
+
+        // default to mapping the param type or using a fallback
+        return `${name} ${this.getTypeFromMap(type) || fallbackReturnType}`
       })
       .join(',')
   }

--- a/src/impl/TsMorph.ts
+++ b/src/impl/TsMorph.ts
@@ -1,4 +1,4 @@
-import { TSCompiler } from 'src/interfaces/TSCompiler.js'
+import { TSCompiler, TSFunction } from 'src/interfaces/TSCompiler.js'
 import { FunctionDeclaration, Project, SourceFile } from 'ts-morph'
 
 export class TsMorph implements TSCompiler {
@@ -28,6 +28,11 @@ export class TsMorph implements TSCompiler {
     return comments
   }
 
+  private getFunctionJsdocTags(fn: FunctionDeclaration): TSFunction['jsdocTags'] {
+    const jsdocTags = fn.getJsDocs().flatMap((jsdoc) => jsdoc.getTags())
+    return jsdocTags.map(tag => ({ name: tag.getTagName(), commentText: tag.getCommentText() || '' }))
+  }
+
   getFunctions() {
     const fns = this.sourceFile.getFunctions()
     return fns.map((fn) => {
@@ -37,6 +42,7 @@ export class TsMorph implements TSCompiler {
         parameters: this.getFunctionParameters(fn),
         comments: this.getFunctionComments(fn),
         returnType: this.getFunctionReturnType(fn),
+        jsdocTags: this.getFunctionJsdocTags(fn),
       }
     })
   }

--- a/src/interfaces/TSCompiler.ts
+++ b/src/interfaces/TSCompiler.ts
@@ -9,6 +9,7 @@ export interface TSFunction {
   parameters: TSFunctionParameter[]
   comments: string[]
   returnType: string
+  jsdocTags: { name: string, commentText: string }[]
 }
 
 export interface TSCompiler {


### PR DESCRIPTION
Hey! I was planning to implement something like `plv8ify` for me and my team, and found that this project is already doing _mostly_ what we need. I know it's ideal to have separate PRs for separate fixes/features, but it was just easier to put everything into one PR for now. I'm happy to split them up if needed, just lmk.

Here's the gist:
- added support for JSDoc tags to decorate functions instead of magic comments
  - this is neat because it uses the jsdoc parsing already provided by ts-morph
  - I tried to keep the format consistent with similar JSDoc tags (`@param` has type first, then param name)
  - using `_` instead of `-` because syntax highlighting doesn't recognize `@plv8ify-whatever` as full tag
  - I think using JSDoc tags would be preferable for most developers, and I updated the examples and the README to reflect that. parsing comments still works for legacy reasons but it's not presented in the README
- type mapping can be controlled on a per-function basis
  - return: `/** @plv8ify_return {<SQL TYPE>} */` or `//@plv8ify-return <SQL TYPE>`
  - param: `/** @plv8ify_param {<SQL TYPE>} <PARAM NAME> */` or `//@plv8ify-param <PARAM NAME> <SQL TYPE>`
    - NOTE: order for the sql type and param name is flipped for jsdoc VS magic comment... maybe this isn't desirable but it might become a non-issue if you decide to remove comment support altogether?
- the examples with custom types weren't using their custom types, fixed
- fixed #49 via use of a symbol
  - I chose the symbol because it's pretty much guaranteed to be unique and avoid collisions
- addressed some `TODO` comments and fixed the "risky" type assertions
- consolidated all the logic for processing jsdoc / comments into a single function that returns a config object describing how the fn should be converted to SQL
- I didn't like how the `TSFunction.returnType` was modified to be a sql type, because it was ambiguous not knowing if the type had been mapped yet. So I decided to keep the value in `returnType` and introduce a separate `sqlReturnType`