### PR TITLE
Introduce a "bundle id"

### DIFF
--- a/src/impl/PLV8ifyCLI.test.ts
+++ b/src/impl/PLV8ifyCLI.test.ts
@@ -11,7 +11,6 @@ describe('PLV8ifyCLI tests', () => {
         name: 'test',
         isExported: true,
         parameters: [],
-        comments: [],
         returnType: 'void',
         jsdocTags: []
       },
@@ -32,7 +31,6 @@ describe('PLV8ifyCLI tests', () => {
         name: 'test',
         isExported: true,
         parameters: [],
-        comments: [],
         returnType: 'void',
         jsdocTags: [],
       },
@@ -57,9 +55,10 @@ describe('PLV8ifyCLI tests', () => {
           { name: 'NEW', type: 'testRow' },
           { name: 'OLD', type: 'testRow' },
         ],
-        comments: ['//@plv8ify-trigger'],
         returnType: 'object',
-        jsdocTags: []
+        jsdocTags: [
+          { name: 'plv8ify_trigger', commentText: '' },
+        ]
       },
       scopePrefix: 'plv8ify_',
       mode: 'inline',
@@ -89,9 +88,10 @@ function test(NEW, OLD) {
         name: 'test',
         isExported: true,
         parameters: [],
-        comments: ['//@plv8ify-schema-name testschema'],
         returnType: 'string',
-        jsdocTags: []
+        jsdocTags: [
+          { name: 'plv8ify_schema_name', commentText: 'testschema' },
+        ]
       },
       scopePrefix: 'plv8ify_',
       mode: 'inline',
@@ -116,7 +116,6 @@ function test() {
         name: 'test',
         isExported: true,
         parameters: [{ name: 'test', type: 'test_type[]' }],
-        comments: [],
         returnType: 'object',
         jsdocTags: []
       },

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -166,7 +166,6 @@ export class PLV8ifyCLI implements PLV8ify {
       // -- PLV8 + Server
       const virtualInitFn: TSFunction = {
         name: '_init',
-        comments: [],
         isExported: false,
         parameters: [],
         returnType: 'void',
@@ -208,7 +207,6 @@ export class PLV8ifyCLI implements PLV8ify {
       const startFunctionName = 'start'
       const virtualStartFn: TSFunction = {
         name: startFunctionName,
-        comments: [],
         isExported: false,
         parameters: [],
         returnType: 'void',
@@ -230,7 +228,7 @@ export class PLV8ifyCLI implements PLV8ify {
   }
 
   /**
-   * handles all the processing for jsdoc / magic comments
+   * handles all the processing for jsdoc
    */
   private getFnSqlConfig (fn: TSFunction): FnSqlConfig {
     const config: FnSqlConfig = {
@@ -245,25 +243,6 @@ export class PLV8ifyCLI implements PLV8ify {
     // default param type mapping
     for (const param of fn.parameters) {
       config.paramTypeMapping[param.name] = this.getTypeFromMap(param.type) || null
-    }
-
-    // process magic comments (legacy format)
-    for (const comment of fn.comments) {
-      const volatilityMatch = comment.match(/^\/\/@plv8ify-volatility-(STABLE|IMMUTABLE|VOLATILE)/umi)
-      if (volatilityMatch) config.volatility = volatilityMatch[1] as Volatility
-
-      const schemaMatch = comment.match(/^\/\/@plv8ify-schema-name (.+)/umi)
-      if (schemaMatch) config.customSchema = schemaMatch[1]
-
-      for (const param of fn.parameters) {
-        const paramMatch = comment.match(/^\/\/@plv8ify-param (.+) ([\s\S]+)/umi)
-        if (paramMatch && paramMatch[1] === param.name) config.paramTypeMapping[param.name] = paramMatch[2]
-      }
-
-      const returnMatch = comment.match(/^\/\/@plv8ify-return ([\s\S]+)/umi)
-      if (returnMatch) config.sqlReturnType = returnMatch[1]
-
-      if (comment.match(/^\/\/@plv8ify-trigger/umi)) config.trigger = true
     }
 
     // process jsdoc tags

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -42,6 +42,7 @@ type FnSqlConfig = {
 export class PLV8ifyCLI implements PLV8ify {
   private _bundler: Bundler
   private _tsCompiler: TSCompiler
+  private bundleId = Date.now()
 
   private _typeMap: Record<string, string> = {
     number: 'float8',
@@ -179,7 +180,7 @@ export class PLV8ifyCLI implements PLV8ify {
         }
 
         // set a global symbol so that we can check if the init function has been called
-        bundledJs += `globalThis[Symbol.for('${scopePrefix}_initialized')] = true;\n`
+        bundledJs += `globalThis[Symbol.for('${scopePrefix}_initialized')] = ${this.bundleId};\n`
       }
 
       const initFunction = this.getPLV8SQLFunction({
@@ -307,7 +308,7 @@ export class PLV8ifyCLI implements PLV8ify {
         .with(
           'bundle',
           () =>
-            `if (!globalThis[Symbol.for('${scopePrefix}_initialized')]) plv8.execute('SELECT ${scopePrefix}_init();');`
+            `if (globalThis[Symbol.for('${scopePrefix}_initialized')] !== ${this.bundleId}) plv8.execute('SELECT ${scopePrefix}_init();');`
         )
         .otherwise(() => ''),
       match(sqlReturnType.toLowerCase())

--- a/src/impl/TsMorph.ts
+++ b/src/impl/TsMorph.ts
@@ -23,24 +23,18 @@ export class TsMorph implements TSCompiler {
     })
   }
 
-  private getFunctionComments(fn: FunctionDeclaration) {
-    const comments = fn.getLeadingCommentRanges().map((cr) => cr.getText())
-    return comments
-  }
-
   private getFunctionJsdocTags(fn: FunctionDeclaration): TSFunction['jsdocTags'] {
     const jsdocTags = fn.getJsDocs().flatMap((jsdoc) => jsdoc.getTags())
     return jsdocTags.map(tag => ({ name: tag.getTagName(), commentText: tag.getCommentText() || '' }))
   }
 
-  getFunctions() {
+  getFunctions(): TSFunction[] {
     const fns = this.sourceFile.getFunctions()
     return fns.map((fn) => {
       return {
         name: fn.getName(),
         isExported: fn.isExported(),
         parameters: this.getFunctionParameters(fn),
-        comments: this.getFunctionComments(fn),
         returnType: this.getFunctionReturnType(fn),
         jsdocTags: this.getFunctionJsdocTags(fn),
       }

--- a/src/interfaces/TSCompiler.ts
+++ b/src/interfaces/TSCompiler.ts
@@ -7,7 +7,6 @@ export interface TSFunction {
   name: string
   isExported: boolean
   parameters: TSFunctionParameter[]
-  comments: string[]
   returnType: string
   jsdocTags: { name: string, commentText: string }[]
 }


### PR DESCRIPTION
Fixes #54 , cleans up old magic comment stuff.

# Bundle ID

The main issue was that `_init` was not called after it gets updated, because the check on `globalThis[Symbol.for('_initialized')]` was looking for a boolean. Now it will look for a match on the ID, which just comes from the timestamp when the build was created.