### PR TITLE
Remove jq installation from terragon-setup.sh

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -6,20 +6,6 @@ export XATA_DATABASENAME=app
 # Install dependencies
 bun install
 
-# Install jq if not present
-if ! command -v jq &> /dev/null; then
-    echo "jq not found, installing..."
-    if command -v apt-get &> /dev/null; then
-        apt-get update && apt-get install -y jq
-    elif command -v yum &> /dev/null; then
-        yum install -y jq
-    elif command -v brew &> /dev/null; then
-        brew install jq
-    else
-        echo "Error: Could not install jq. Please install it manually."
-        exit 1
-    fi
-fi
 
 # Install Xata CLI
 curl -fsSL https://xata.io/install.sh | bash


### PR DESCRIPTION
## Summary
- Removed automatic installation of jq from the terragon-setup.sh script
- Simplifies setup by assuming jq is either pre-installed or manually installed by the user

## Changes

### Setup Script
- Deleted jq installation block that checked for jq presence and installed it via apt-get, yum, or brew
- Retained bun install and Xata CLI installation steps

## Reasoning
- jq installation can be environment-specific and may require manual intervention
- Reduces complexity and potential errors during setup

## Test plan
- Run terragon-setup.sh on a clean environment without jq to verify it no longer attempts jq installation
- Confirm bun dependencies and Xata CLI install correctly without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/324e587a-777a-4002-adcd-5055ea7f463a