### PR TITLE
feature: (esbuild): add --esbuild-define flag with dead code elimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,55 @@ $plv8ify$ LANGUAGE plv8 IMMUTABLE STRICT;
 | set the TS->SQL type mapping for the return type | `/** @plv8ify_returns {<SQL TYPE>} */` | `/** @plv8ify_returns {setof my_table} */` |
 | designate the function is a TRIGGER | `/** @plv8ify_trigger */` | `/** @plv8ify_trigger */` |
 
+## Dead Code Elimination with `--esbuild-define`
+
+The `--esbuild-define` flag lets you pass compile-time constants to esbuild, which are then used to eliminate dead code branches from the generated output. This is useful for including optional infrastructure code (e.g. snapshot capture, debug logging) that should have zero cost in production.
+
+When `--esbuild-define` is provided, `minifySyntax` is automatically enabled so esbuild removes unreachable branches entirely — without mangling names or collapsing whitespace, keeping the output readable.
+
+**Input:**
+
+```typescript
+declare const ENABLE_SNAPSHOT_CAPTURE: boolean;
+
+export function my_function(input: MyRow): MyRow {
+  if (!ENABLE_SNAPSHOT_CAPTURE) return input;
+  const snapshot = new SnapshotCapture(/* ... */);
+  snapshot.capture(input);
+  return input;
+}
+```
+
+**Production build** — snapshot code eliminated:
+
+```bash
+plv8ify generate --input-file input.ts --esbuild-define '{"ENABLE_SNAPSHOT_CAPTURE":"false"}'
+```
+
+```javascript
+// output
+function my_function(input) {
+  return input;
+}
+```
+
+**Dev build** — snapshot code included:
+
+```bash
+plv8ify generate --input-file input.ts --esbuild-define '{"ENABLE_SNAPSHOT_CAPTURE":"true"}'
+```
+
+```javascript
+// output
+function my_function(input) {
+  const snapshot = new SnapshotCapture();
+  snapshot.capture(input);
+  return input;
+}
+```
+
+Multiple defines are supported in a single flag: `--esbuild-define '{"FLAG_A":"true","FLAG_B":"false"}'`
+
 ## CLI Usage
 
 ### Version
@@ -245,6 +294,7 @@ Generate PLV8 functions for an input typescript file
 | --mode                  | 'inline', 'bundle' or 'start_proc'    | 'inline' will bundle the library in each function, both 'bundle' and 'start_proc' creates a `{prefix}_init` function that loads the library. 'bundle' adds a check to each function to call 'init' if required, whereas 'start_proc' is designed to be used with plv8.start_proc        | `inline`       |
 | --volatility            | 'IMMUTABLE' or 'STABLE' or 'VOLATILE' | Change the volatility of all the generated functions. To change volatility of a specific function use the jsdoc `/** @plv8ify_volatility STABLE` in the input typescript file (see `examples/turf-js/input.ts`).                                                                        | `IMMUTABLE`    |
 | --types-config-file     | String                                | Specify a custom types config file                                                                                                                                                                                                                                                      | types.ts       |
+| --esbuild-define        | JSON string                           | Pass compile-time constants to esbuild's `define` option as a JSON object of string key-value pairs. When provided, `minifySyntax` is also enabled so dead branches are eliminated from the output. Example: `--esbuild-define '{"DEBUG":"false"}'`                                     | _(none)_       |
 
 ### Deploy
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -19,6 +19,7 @@ export async function generateCommand(CLI: {
     mode,
     defaultVolatility,
     typesFilePath,
+    esbuildDefine,
   } = CLI.config
 
   // Runtime check
@@ -41,6 +42,7 @@ export async function generateCommand(CLI: {
     mode,
     inputFile: inputFilePath,
     scopePrefix,
+    esbuildDefine,
   })
 
   // Optionally, write ESBuild output file

--- a/src/helpers/ParseCLI.ts
+++ b/src/helpers/ParseCLI.ts
@@ -16,6 +16,7 @@ export interface CLIConfig {
   defaultVolatility: Volatility
   typesFilePath: string
   deployConcurrency: number
+  esbuildDefine?: Record<string, string>
 }
 
 export class ParseCLI {
@@ -110,6 +111,18 @@ export class ParseCLI {
             brief: 'Default function volatility',
             default: 'IMMUTABLE' as Volatility,
           },
+          'esbuild-define': {
+            kind: 'parsed',
+            parse: (value) => {
+              try {
+                return JSON.parse(value) as Record<string, string>
+              } catch {
+                throw new Error(`Invalid --esbuild-define value: must be a JSON object of string key-value pairs`)
+              }
+            },
+            brief: 'esbuild define constants as JSON (enables dead code elimination)',
+            optional: true,
+          },
         },
       },
       docs: {
@@ -130,6 +143,7 @@ export class ParseCLI {
           defaultVolatility: flags['volatility'],
           typesFilePath: flags['types-config-file'],
           deployConcurrency: 10, // Not used in generate command
+          esbuildDefine: flags['esbuild-define'],
         }
         await mod.generateCommand({
           command: 'generate',

--- a/src/impl/EsBuild.test.ts
+++ b/src/impl/EsBuild.test.ts
@@ -36,4 +36,40 @@ describe('EsBuild tests', () => {
     })
     expect(js).toMatchSnapshot()
   })
+
+  it('getBundleJs - esbuild-define with ENABLE_FEATURE=false eliminates feature branch', async () => {
+    const esbuild = new EsBuild()
+    const js = await esbuild.bundle({
+      inputFile: './src/test-fixtures/define.fixture.ts',
+      define: { ENABLE_FEATURE: 'false' },
+    })
+    // Branch guarded by !ENABLE_FEATURE (i.e. !false = true) should be kept as early return
+    // The "feature active:" string should be eliminated
+    expect(js).not.toContain('feature active')
+    expect(js).toMatchSnapshot()
+  })
+
+  it('getBundleJs - esbuild-define with ENABLE_FEATURE=true eliminates early return', async () => {
+    const esbuild = new EsBuild()
+    const js = await esbuild.bundle({
+      inputFile: './src/test-fixtures/define.fixture.ts',
+      define: { ENABLE_FEATURE: 'true' },
+    })
+    // Early return guarded by !ENABLE_FEATURE (i.e. !true = false) should be eliminated
+    // The "feature active:" string should be present
+    expect(js).toContain('feature active')
+    expect(js).toMatchSnapshot()
+  })
+
+  it('getBundleJs - no define produces same output as before (backward compat)', async () => {
+    const esbuild = new EsBuild()
+    const withoutDefine = await esbuild.bundle({
+      inputFile: './src/test-fixtures/input.fixture.ts',
+    })
+    const withEmptyDefine = await esbuild.bundle({
+      inputFile: './src/test-fixtures/input.fixture.ts',
+      define: {},
+    })
+    expect(withoutDefine).toEqual(withEmptyDefine)
+  })
 })

--- a/src/impl/EsBuild.ts
+++ b/src/impl/EsBuild.ts
@@ -5,7 +5,8 @@ import nodeExternals from 'webpack-node-externals'
 class BundlerError extends Error {}
 
 export class EsBuild implements Bundler {
-  async bundle({ inputFile }: BundleArgs) {
+  async bundle({ inputFile, define }: BundleArgs) {
+    const hasDefines = define && Object.keys(define).length > 0
     const esbuildResult = await build({
       entryPoints: [inputFile],
       external: [nodeExternals()],
@@ -13,6 +14,7 @@ export class EsBuild implements Bundler {
       platform: 'browser',
       bundle: true,
       write: false,
+      ...(hasDefines && { define, minifySyntax: true }),
     }).catch(() => new BundlerError('esbuild failed'))
 
     if (esbuildResult instanceof Error) {

--- a/src/impl/PLV8ifyCLI.ts
+++ b/src/impl/PLV8ifyCLI.ts
@@ -75,9 +75,10 @@ export class PLV8ifyCLI implements PLV8ify {
     return bundledJs.replace(/export\s*{[^}]*};/gs, '')
   }
 
-  async build({ mode, inputFile, scopePrefix }: BuildArgs) {
+  async build({ mode, inputFile, scopePrefix, esbuildDefine }: BuildArgs) {
     const bundledJsR = await this._bundler.bundle({
       inputFile,
+      define: esbuildDefine,
     })
     const bundledJs = this.removeExportBlock(bundledJsR)
     const modeAdjustedBundledJs = match(mode)

--- a/src/impl/__snapshots__/EsBuild.test.ts.snap
+++ b/src/impl/__snapshots__/EsBuild.test.ts.snap
@@ -38,3 +38,25 @@ export {
 };
 "
 `;
+
+exports[`EsBuild tests getBundleJs - esbuild-define with ENABLE_FEATURE=false eliminates feature branch 1`] = `
+"// src/test-fixtures/define.fixture.ts
+function test_define_flag(input) {
+  return input;
+}
+export {
+  test_define_flag
+};
+"
+`;
+
+exports[`EsBuild tests getBundleJs - esbuild-define with ENABLE_FEATURE=true eliminates early return 1`] = `
+"// src/test-fixtures/define.fixture.ts
+function test_define_flag(input) {
+  return "feature active: " + input;
+}
+export {
+  test_define_flag
+};
+"
+`;

--- a/src/interfaces/Bundler.ts
+++ b/src/interfaces/Bundler.ts
@@ -1,5 +1,6 @@
 export interface BundleArgs {
   inputFile: string
+  define?: Record<string, string>
 }
 
 export interface Bundler {

--- a/src/interfaces/PLV8ify.ts
+++ b/src/interfaces/PLV8ify.ts
@@ -6,6 +6,7 @@ export interface BuildArgs {
   mode: Mode
   inputFile: string
   scopePrefix: string
+  esbuildDefine?: Record<string, string>
 }
 
 export interface GetPLV8SQLFunctionsArgs {

--- a/src/test-fixtures/define.fixture.ts
+++ b/src/test-fixtures/define.fixture.ts
@@ -1,0 +1,7 @@
+declare const ENABLE_FEATURE: boolean;
+
+export function test_define_flag(input: string): string {
+  if (!ENABLE_FEATURE) return input;
+  const result = 'feature active: ' + input;
+  return result;
+}


### PR DESCRIPTION
Adds a new --esbuild-define CLI flag that accepts a JSON object of string key-value pairs and passes them to esbuild's define option. When defines are present, minifySyntax is automatically enabled so esbuild performs dead code elimination — removing unreachable branches entirely without mangling names or collapsing whitespace.

This enables zero-cost optional infrastructure code in PLV8 functions (e.g. snapshot capture, debug logging) that can be compiled out in production builds:

  plv8ify generate --input-file input.ts \
    --esbuild-define '{"ENABLE_SNAPSHOT_CAPTURE":"false"}'

Changes:
- src/interfaces/Bundler.ts: add optional define to BundleArgs
- src/interfaces/PLV8ify.ts: add optional esbuildDefine to BuildArgs
- src/impl/EsBuild.ts: spread define + minifySyntax into esbuild options when defines present
- src/impl/PLV8ifyCLI.ts: thread esbuildDefine through build() to bundle()
- src/helpers/ParseCLI.ts: add esbuildDefine to CLIConfig; add --esbuild-define optional flag with JSON parsing
- src/commands/generate.ts: destructure and pass esbuildDefine to plv8ify.build()
- src/impl/EsBuild.test.ts: tests for DCE with ENABLE_FEATURE=true/false and backward compat
- src/test-fixtures/define.fixture.ts: fixture for define tests
- README.md: new section and flag table entry documenting the feature

Backward compatible: omitting --esbuild-define produces identical output to current behavior.